### PR TITLE
add a name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "map-dater",
   "bin": {
     "map-dater": "./src/index.js"
   },


### PR DESCRIPTION
It seems like this is needed, since I get the following error when installing via `npm`:

```
npm ERR! No name provided in package.json
```
